### PR TITLE
sets default urls to cloud-gov

### DIFF
--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -59,8 +59,8 @@ func (d *DDConfig) setGodojoDefaults() {
 
 	// Set some installer defaults - .deb specific
 	d.helpURL = "https://github.com/DefectDojo/godojo"
-	d.releaseURL = "https://github.com/DefectDojo/django-DefectDojo/archive/"
-	d.cloneURL = "https://github.com/DefectDojo/django-DefectDojo.git"
+	d.releaseURL = "https://github.com/cloud-gov/django-DefectDojo/archive/"
+	d.cloneURL = "https://github.com/cloud-gov/django-DefectDojo.git"
 	d.yarnGPG = "https://dl.yarnpkg.com/debian/pubkey.gpg"
 	d.yarnRepo = "deb https://dl.yarnpkg.com/debian/ stable main"
 	d.nodeURL = "https://deb.nodesource.com/setup_18.x"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Sets release and clone url to cloud-gov so that we can use our modified Defect Dojo code

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None